### PR TITLE
fix: use default foreground color for main page title

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -32,7 +32,7 @@ export default async function Home() {
               className="w-auto h-auto max-w-full"
               priority
             />
-            <h1 className="text-3xl font-bold text-white mt-4">Siebert Science AI Tutor</h1>
+            <h1 className="text-3xl font-bold mt-4">Siebert Science AI Tutor</h1>
           </div>
           <div className="w-full max-w-4xl">
             <Chat/>


### PR DESCRIPTION
Removes the hardcoded text-white class from the main page title so it inherits the CSS variable-based foreground color
  (#171717 in light mode, #ededed in dark mode) defined in globals.css.
