### PR TITLE
Feat: Stream LLM responses to the UI + Disable RAG

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "eslint-plugin-prettier": "5.5.4",
     "jsdom": "26.1.0",
     "pdf-parse": "^2.4.5",
-    "playwright": "1.55.1",
     "prettier": "3.6.2",
     "tailwindcss": "4.1.13",
     "tsx": "^4.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,9 +126,6 @@ importers:
       pdf-parse:
         specifier: ^2.4.5
         version: 2.4.5
-      playwright:
-        specifier: 1.55.1
-        version: 1.55.1
       prettier:
         specifier: 3.6.2
         version: 3.6.2
@@ -3202,18 +3199,8 @@ packages:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
 
-  playwright-core@1.55.1:
-    resolution: {integrity: sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==}
-    engines: {node: '>=18'}
-    hasBin: true
-
   playwright-core@1.58.2:
     resolution: {integrity: sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  playwright@1.55.1:
-    resolution: {integrity: sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -6925,15 +6912,7 @@ snapshots:
 
   picomatch@4.0.3: {}
 
-  playwright-core@1.55.1: {}
-
   playwright-core@1.58.2: {}
-
-  playwright@1.55.1:
-    dependencies:
-      playwright-core: 1.55.1
-    optionalDependencies:
-      fsevents: 2.3.2
 
   playwright@1.58.2:
     dependencies:

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,7 +1,7 @@
 import { streamText, StreamData } from "ai";
 import { openai } from "@ai-sdk/openai";
 import { SYSTEM_PROMPT } from "../../prompts";
-import { MODEL } from "../../../lib/constants";
+import { MODEL, RAG_ENABLED } from "../../../lib/constants";
 import { retrieveRelevantChunks } from "#/lib/rag/retrieval";
 import { formatContextMessage, chunksToReferences } from "#/lib/rag/context";
 import type { RagError, Reference, RetrievedChunk } from "#/lib/rag/types";
@@ -30,7 +30,7 @@ export async function POST(req: Request) {
     let references: Reference[] = [];
     let ragError: RagError | undefined;
 
-    if (lastUserMessage?.content) {
+    if (RAG_ENABLED && lastUserMessage?.content) {
       console.log("[CHAT] Starting RAG retrieval for user message:", lastUserMessage.content.substring(0, 100));
       try {
         relevantChunks = await retrieveRelevantChunks(lastUserMessage.content);
@@ -42,8 +42,6 @@ export async function POST(req: Request) {
           message: error instanceof Error ? error.message : String(error),
         };
       }
-    } else {
-      console.log("[CHAT] No user message found for RAG retrieval");
     }
 
     // Build messages with optional context injection

--- a/src/app/api/chat/route.ts
+++ b/src/app/api/chat/route.ts
@@ -1,4 +1,4 @@
-import { generateText } from "ai";
+import { streamText, StreamData } from "ai";
 import { openai } from "@ai-sdk/openai";
 import { SYSTEM_PROMPT } from "../../prompts";
 import { MODEL } from "../../../lib/constants";
@@ -54,20 +54,18 @@ export async function POST(req: Request) {
       ...messages,
     ];
 
-    // Ask OpenAI for a complete chat completion given the prompt
-    const response = await generateText({
+    // Stream the response and attach references as data.
+    // JSON.parse/stringify round-trip converts typed interfaces to plain JSONValue.
+    const streamData = new StreamData();
+    streamData.append(JSON.parse(JSON.stringify({ references, ...(ragError && { ragError }) })));
+
+    const result = streamText({
       model: openai(MODEL),
       messages: messagesWithContext,
+      onFinish: () => streamData.close(),
     });
 
-    // Return the complete response as JSON with references
-    return Response.json({
-      id: Date.now().toString(),
-      role: "assistant",
-      content: response.text,
-      references,
-      ...(ragError && { ragError }),
-    });
+    return result.toDataStreamResponse({ data: streamData });
   } catch (e) {
     console.error('error in chat route', e);
     return Response.json(

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -60,11 +60,32 @@ const Chat: React.FC = () => {
 
     setMessages(prev => [...prev, userMessage]);
     setInput("");
-    setIsLoading(true);
 
-    // todo: move this into a http helper that returns parsed data or an error message
-    const newMessage = await submitMessages(messages, userMessage, setMessages, setIsLoading);
-    setMessages(prev => [...prev, newMessage]);
+    const streamingId = `${Date.now()}-ai`;
+    setIsLoading(true);
+    setMessages(prev => [...prev, { id: streamingId, role: "assistant" as const, content: "" }]);
+
+    await submitMessages(
+      messages,
+      userMessage,
+      (chunk) => {
+        setMessages(prev =>
+          prev.map(m => m.id === streamingId ? { ...m, content: m.content + chunk } : m)
+        );
+      },
+      (references, ragError) => {
+        setMessages(prev =>
+          prev.map(m => {
+            if (m.id !== streamingId) return m;
+            const updated: MessageWithReferences = { ...m };
+            if (references.length > 0) updated.references = references;
+            if (ragError) updated.ragError = ragError;
+            return updated;
+          })
+        );
+        setIsLoading(false);
+      }
+    );
 
     await resumeAfterResponse();
   };

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -93,11 +93,6 @@ const Chat: React.FC = () => {
   return (
     <div id="chat" className="w-full max-w-4xl mx-auto">
       <Messages messages={messages} />
-      {isLoading && (
-        <div className="text-center py-4 text-gray-600">
-          <span>AI is thinking...</span>
-        </div>
-      )}
       <form onSubmit={handleMessageSubmit} className="w-full">
         <div className="w-full relative">
           <div className="bg-gray-100 rounded-xl p-4 border border-gray-200 relative">

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -12,22 +12,21 @@ export interface MessageWithReferences {
 }
 
 export default function Messages({ messages }: { messages: MessageWithReferences[] }) {
-  const messagesEndRef = useRef<HTMLDivElement | null>(null);
-
-  const scrollToBottom = () => {
-    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
-  };
+  const lastUserMessageRef = useRef<HTMLDivElement | null>(null);
+  const userMessageCount = messages.filter(m => m.role === "user").length;
+  const lastUserIndex = messages.reduce((last, msg, i) => msg.role === "user" ? i : last, -1);
 
   useEffect(() => {
-    scrollToBottom();
-  }, [messages]);
+    lastUserMessageRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+  }, [userMessageCount]);
 
   return (
     <div className="space-y-4 mb-4">
       {messages.map((msg, index) => (
         <div
           key={index}
-          className={"p-4 rounded-lg bg-white dark:bg-black text-gray-950 dark:text-white border border-gray-400 dark:border-gray-600"}
+          ref={index === lastUserIndex ? lastUserMessageRef : null}
+          className={"scroll-mt-[68px] p-4 rounded-lg bg-white dark:bg-black text-gray-950 dark:text-white border border-gray-400 dark:border-gray-600"}
         >
           <div className="flex items-start gap-3">
             <div className="text-lg">
@@ -46,7 +45,6 @@ export default function Messages({ messages }: { messages: MessageWithReferences
           )}
         </div>
       ))}
-      <div ref={messagesEndRef} />
     </div>
   );
 }

--- a/src/components/Messages.tsx
+++ b/src/components/Messages.tsx
@@ -34,7 +34,11 @@ export default function Messages({ messages }: { messages: MessageWithReferences
               {msg.role === "assistant" ? "🤖" : "🧑‍💻"}
             </div>
             <div className="flex-1 prose prose-base max-w-none dark:prose-invert">
-              <ReactMarkdown>{msg.content}</ReactMarkdown>
+              {msg.role === "assistant" && msg.content === "" ? (
+                <p className="animate-pulse">AI is thinking...</p>
+              ) : (
+                <ReactMarkdown>{msg.content}</ReactMarkdown>
+              )}
             </div>
           </div>
           {msg.role === "assistant" && ((msg.references && msg.references.length > 0) || msg.ragError) && (

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -87,6 +87,7 @@ export const useSpeechRecognition = (onTranscript: (transcript: string) => void,
   };
 
   const pauseForSubmit = (): void => {
+    if (!isRecordingOrLoading) return;
     if (ttsMethod === TtsMethod.Deepgram || ttsMethod === TtsMethod.DeepgramMedical) {
       pauseMicrophone();
       setRecordingState(RecordingState.Paused);

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,6 +1,7 @@
 export const MODEL = "gpt-5";
 
 // RAG Configuration
+export const RAG_ENABLED = false;
 export const EMBEDDING_MODEL = "text-embedding-3-small";
 export const EMBEDDING_DIMENSIONS = 1536;
 export const SIMILARITY_THRESHOLD = 0.6;

--- a/src/lib/http/submitMessages.ts
+++ b/src/lib/http/submitMessages.ts
@@ -1,13 +1,12 @@
 import type { MessageWithReferences } from "#/components/Messages";
+import type { Reference, RagError } from "#/lib/rag/types";
 
 export default async function submitMessages(
   messages: MessageWithReferences[],
   userMessage: MessageWithReferences,
-  setMessages: React.Dispatch<React.SetStateAction<MessageWithReferences[]>>,
-  setIsLoading: React.Dispatch<React.SetStateAction<boolean>>
-) {
-  let newMessage: MessageWithReferences;
-
+  onChunk: (text: string) => void,
+  onComplete: (references: Reference[], ragError?: RagError) => void
+): Promise<void> {
   try {
     const response = await fetch("/api/chat", {
       method: "POST",
@@ -19,21 +18,42 @@ export default async function submitMessages(
       }),
     });
 
-    if (!response.ok) {
+    if (!response.ok || !response.body) {
       throw new Error("Failed to get response");
     }
 
-    newMessage = await response.json();
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let references: Reference[] = [];
+    let ragError: RagError | undefined;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        if (line.startsWith("0:")) {
+          onChunk(JSON.parse(line.slice(2)));
+        } else if (line.startsWith("2:")) {
+          const items: Array<{ references?: Reference[]; ragError?: RagError }> =
+            JSON.parse(line.slice(2));
+          for (const item of items) {
+            if (item.references) references = item.references;
+            if (item.ragError) ragError = item.ragError;
+          }
+        }
+      }
+    }
+
+    onComplete(references, ragError);
   } catch (error) {
     console.error("Error sending message:", error);
-    newMessage = {
-      id: Date.now().toString(),
-      role: "assistant",
-      content: "Sorry, I encountered an error. Please try again.",
-    };
-  } finally {
-    setIsLoading(false);
+    onChunk("Sorry, I encountered an error. Please try again.");
+    onComplete([]);
   }
-
-  return newMessage;
 }

--- a/tests/e2e/chat.spec.ts
+++ b/tests/e2e/chat.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test'
+import { loginUser } from './utils/auth'
+import { selectors } from './utils/selectors'
+
+const MOCK_STREAM = [
+  '2:[{"references":[{"documentName":"anatomy.pdf","pageNumber":1,"snippet":"The heart has four chambers.","similarity":0.9}]}]\n',
+  '0:"The "\n',
+  '0:"heart "\n',
+  '0:"has "\n',
+  '0:"four "\n',
+  '0:"chambers."\n',
+  'd:{"finishReason":"stop","usage":{"promptTokens":10,"completionTokens":5}}\n',
+].join('')
+
+test.describe('Chat', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.route('/api/chat', (route) =>
+      route.fulfill({
+        status: 200,
+        headers: {
+          'Content-Type': 'text/plain; charset=utf-8',
+          'x-vercel-ai-data-stream': 'v1',
+        },
+        body: MOCK_STREAM,
+      })
+    )
+    await loginUser(page)
+  })
+
+  test('streams response text into the assistant message', async ({ page }) => {
+    await page.fill(selectors.messageInput, 'How many chambers does the heart have?')
+    await page.keyboard.press('Enter')
+
+    await expect(page.locator('text=How many chambers does the heart have?')).toBeVisible()
+    await expect(page.locator('text=The heart has four chambers.')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('hides the thinking indicator after streaming completes', async ({ page }) => {
+    await page.fill(selectors.messageInput, 'What is the heart?')
+    await page.keyboard.press('Enter')
+
+    await expect(page.locator('text=The heart has four chambers.')).toBeVisible({ timeout: 10000 })
+    await expect(page.locator('text=AI is thinking...')).not.toBeVisible()
+  })
+
+  test('displays references after streaming completes', async ({ page }) => {
+    await page.fill(selectors.messageInput, 'What is the heart?')
+    await page.keyboard.press('Enter')
+
+    await expect(page.locator('text=The heart has four chambers.')).toBeVisible({ timeout: 10000 })
+    // References section shows "1 source" toggle (collapsed by default)
+    await expect(page.locator('text=1 source')).toBeVisible()
+  })
+
+  test('input re-enables after streaming completes', async ({ page }) => {
+    await page.fill(selectors.messageInput, 'What is the heart?')
+    await page.keyboard.press('Enter')
+
+    await expect(page.locator('text=The heart has four chambers.')).toBeVisible({ timeout: 10000 })
+    await expect(page.locator(selectors.messageInput)).toBeEnabled()
+  })
+})

--- a/tests/e2e/chat.spec.ts
+++ b/tests/e2e/chat.spec.ts
@@ -3,7 +3,7 @@ import { loginUser } from './utils/auth'
 import { selectors } from './utils/selectors'
 
 const MOCK_STREAM = [
-  '2:[{"references":[{"documentName":"anatomy.pdf","pageNumber":1,"snippet":"The heart has four chambers.","similarity":0.9}]}]\n',
+  '2:[{"references":[{"documentName":"anatomy.pdf","pageNumber":1,"snippet":"The heart has four chambers.","similarity":0.9},{"documentName":"physiology.pdf","pageNumber":3,"snippet":"The ventricles pump blood.","similarity":0.75}]}]\n',
   '0:"The "\n',
   '0:"heart "\n',
   '0:"has "\n',
@@ -48,8 +48,21 @@ test.describe('Chat', () => {
     await page.keyboard.press('Enter')
 
     await expect(page.locator('text=The heart has four chambers.')).toBeVisible({ timeout: 10000 })
-    // References section shows "1 source" toggle (collapsed by default)
-    await expect(page.locator('text=1 source')).toBeVisible()
+
+    // Toggle is collapsed by default showing the source count
+    await expect(page.locator('text=2 sources')).toBeVisible()
+
+    // Expand references
+    await page.getByRole('button', { name: /2 sources/ }).click()
+
+    // Both references should now be visible with correct metadata
+    await expect(page.locator('text=anatomy.pdf')).toBeVisible({ timeout: 5000 })
+    await expect(page.locator('text=(Page 1)')).toBeVisible()
+    await expect(page.locator('text=90% match')).toBeVisible()
+
+    await expect(page.locator('text=physiology.pdf')).toBeVisible()
+    await expect(page.locator('text=(Page 3)')).toBeVisible()
+    await expect(page.locator('text=75% match')).toBeVisible()
   })
 
   test('input re-enables after streaming completes', async ({ page }) => {

--- a/tests/e2e/page-load.spec.ts
+++ b/tests/e2e/page-load.spec.ts
@@ -2,7 +2,6 @@ import { test, expect } from '@playwright/test'
 import { loginUser } from './utils/auth'
 import { selectors } from './utils/selectors'
 import { MODEL } from '../../src/lib/constants'
-import { LAST_UPDATED } from '../../src/app/prompts'
 
 test.describe('Authentication & Initial Page Load', () => {
   test('should redirect to login page when not authenticated', async ({ page }) => {

--- a/tests/integration/chat-rag.test.ts
+++ b/tests/integration/chat-rag.test.ts
@@ -1,17 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
 
-// Hoist mock functions
+// Hoist mock functions and MockStreamData class
 const {
-  mockGenerateText,
+  mockStreamText,
   mockEmbed,
   mockEmbedding,
   mockSelect,
-  mockFrom,
-  mockInnerJoin,
-  mockWhere,
-  mockOrderBy,
   mockLimit,
+  MockStreamData,
 } = vi.hoisted(() => {
   const mockLimit = vi.fn();
   const mockOrderBy = vi.fn(() => ({ limit: mockLimit }));
@@ -19,11 +16,18 @@ const {
   const mockInnerJoin = vi.fn(() => ({ where: mockWhere }));
   const mockFrom = vi.fn(() => ({ innerJoin: mockInnerJoin }));
   const mockSelect = vi.fn(() => ({ from: mockFrom }));
-  const mockGenerateText = vi.fn();
+  const mockStreamText = vi.fn();
   const mockEmbed = vi.fn();
   const mockEmbedding = vi.fn().mockReturnValue("mocked-embedding-model");
+
+  class MockStreamData {
+    items: unknown[] = [];
+    append(value: unknown) { this.items.push(value); }
+    close() {}
+  }
+
   return {
-    mockGenerateText,
+    mockStreamText,
     mockEmbed,
     mockEmbedding,
     mockSelect,
@@ -32,11 +36,13 @@ const {
     mockWhere,
     mockOrderBy,
     mockLimit,
+    MockStreamData,
   };
 });
 
 vi.mock("ai", () => ({
-  generateText: mockGenerateText,
+  streamText: mockStreamText,
+  StreamData: MockStreamData,
   embed: mockEmbed,
 }));
 
@@ -55,12 +61,60 @@ vi.mock("#/db", () => ({
 // Import after mocks
 import { POST } from "#/app/api/chat/route";
 
+// Helper: parse a Vercel AI data stream response into text and data items
+async function readDataStream(response: Response) {
+  const reader = response.body!.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  let text = "";
+  const data: unknown[] = [];
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split("\n");
+    buffer = lines.pop() ?? "";
+    for (const line of lines) {
+      if (line.startsWith("0:")) text += JSON.parse(line.slice(2));
+      else if (line.startsWith("2:")) data.push(...JSON.parse(line.slice(2)));
+    }
+  }
+  return { text, data };
+}
+
+// Helper: build a mock stream response for a given text, calling onFinish
+function buildStreamResponse(
+  text: string,
+  streamData: InstanceType<typeof MockStreamData>,
+  onFinish?: () => void
+): Response {
+  onFinish?.();
+  const dataLine = `2:${JSON.stringify(streamData.items)}\n`;
+  const textLine = `0:${JSON.stringify(text)}\n`;
+  const finishLine = `d:{"finishReason":"stop"}\n`;
+  return new Response(dataLine + textLine + finishLine, {
+    headers: { "Content-Type": "text/plain; charset=utf-8" },
+  });
+}
+
 describe("Chat API with RAG", () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
     vi.clearAllMocks();
     process.env = { ...originalEnv, OPENAI_API_KEY: "test-key" };
+
+    mockStreamText.mockImplementation(
+      ({ onFinish }: { onFinish?: () => void }) => ({
+        toDataStreamResponse: ({ data }: { data: InstanceType<typeof MockStreamData> }) =>
+          buildStreamResponse(
+            "The heart has four chambers: two atria and two ventricles.",
+            data,
+            onFinish
+          ),
+      })
+    );
   });
 
   afterEach(() => {
@@ -104,11 +158,6 @@ describe("Chat API with RAG", () => {
     ];
     mockLimit.mockResolvedValue(mockChunks);
 
-    // Arrange - mock AI response
-    mockGenerateText.mockResolvedValue({
-      text: "The heart has four chambers: two atria and two ventricles.",
-    });
-
     const request = new NextRequest("http://localhost:3000/api/chat", {
       method: "POST",
       body: JSON.stringify({
@@ -123,16 +172,16 @@ describe("Chat API with RAG", () => {
 
     // Act
     const response = await POST(request);
-    const data = await response.json();
+    const { text, data } = await readDataStream(response);
 
     // Assert - response includes content and references
     expect(response.status).toBe(200);
-    expect(data.content).toBe("The heart has four chambers: two atria and two ventricles.");
-    expect(data.references).toBeDefined();
-    expect(data.references).toHaveLength(2);
+    expect(text).toBe("The heart has four chambers: two atria and two ventricles.");
+    const payload = data[0] as { references: Array<{ documentName: string; pageNumber: number; snippet: string; similarity: number }> };
+    expect(payload.references).toHaveLength(2);
 
     // Assert - references have correct structure
-    expect(data.references[0]).toMatchObject({
+    expect(payload.references[0]).toMatchObject({
       documentName: "anatomy-textbook.pdf",
       pageNumber: 1,
       snippet: "The heart has four chambers.",
@@ -146,8 +195,8 @@ describe("Chat API with RAG", () => {
       })
     );
 
-    // Assert - generateText was called with context injected
-    expect(mockGenerateText).toHaveBeenCalledWith(
+    // Assert - streamText was called with context injected
+    expect(mockStreamText).toHaveBeenCalledWith(
       expect.objectContaining({
         messages: expect.arrayContaining([
           expect.objectContaining({ role: "system" }), // SYSTEM_PROMPT
@@ -167,10 +216,12 @@ describe("Chat API with RAG", () => {
     // Arrange - mock database returning no relevant chunks (empty array)
     mockLimit.mockResolvedValue([]);
 
-    // Arrange - mock AI response
-    mockGenerateText.mockResolvedValue({
-      text: "I can help you with anatomy questions.",
-    });
+    mockStreamText.mockImplementation(
+      ({ onFinish }: { onFinish?: () => void }) => ({
+        toDataStreamResponse: ({ data }: { data: InstanceType<typeof MockStreamData> }) =>
+          buildStreamResponse("I can help you with anatomy questions.", data, onFinish),
+      })
+    );
 
     const request = new NextRequest("http://localhost:3000/api/chat", {
       method: "POST",
@@ -181,19 +232,19 @@ describe("Chat API with RAG", () => {
 
     // Act
     const response = await POST(request);
-    const data = await response.json();
+    const { text, data } = await readDataStream(response);
 
     // Assert - response works normally
     expect(response.status).toBe(200);
-    expect(data.content).toBe("I can help you with anatomy questions.");
+    expect(text).toBe("I can help you with anatomy questions.");
 
     // Assert - no references or empty references array
-    expect(data.references).toEqual([]);
+    const payload = data[0] as { references: unknown[] };
+    expect(payload.references).toEqual([]);
 
-    // Assert - generateText was called without context injection
-    const generateTextCall = mockGenerateText.mock.calls[0]?.[0];
-    expect(generateTextCall).toBeDefined();
-    const systemMessages = generateTextCall.messages.filter(
+    // Assert - streamText was called without context injection
+    const streamTextCall = mockStreamText.mock.calls[0]![0];
+    const systemMessages = streamTextCall.messages.filter(
       (m: { role: string }) => m.role === "system"
     );
     // Should only have the main SYSTEM_PROMPT, not additional context
@@ -204,7 +255,7 @@ describe("Chat API with RAG", () => {
     // Arrange
     mockEmbed.mockResolvedValue({ embedding: new Array(1536).fill(0.5) });
 
-    // Create 7 chunks - should only use top 5 (MAX_RETRIEVAL_CHUNKS)
+    // Create 5 chunks at MAX_RETRIEVAL_CHUNKS limit
     const mockChunks = Array.from({ length: 5 }, (_, i) => ({
       id: `chunk-${i}`,
       documentId: "doc-1",
@@ -220,7 +271,12 @@ describe("Chat API with RAG", () => {
     }));
     mockLimit.mockResolvedValue(mockChunks);
 
-    mockGenerateText.mockResolvedValue({ text: "Response text" });
+    mockStreamText.mockImplementation(
+      ({ onFinish }: { onFinish?: () => void }) => ({
+        toDataStreamResponse: ({ data }: { data: InstanceType<typeof MockStreamData> }) =>
+          buildStreamResponse("Response text", data, onFinish),
+      })
+    );
 
     const request = new NextRequest("http://localhost:3000/api/chat", {
       method: "POST",
@@ -231,23 +287,30 @@ describe("Chat API with RAG", () => {
 
     // Act
     const response = await POST(request);
-    const data = await response.json();
+    const { data } = await readDataStream(response);
 
     // Assert - only MAX_RETRIEVAL_CHUNKS (5) references returned
-    expect(data.references).toHaveLength(5);
+    const payload = data[0] as { references: Array<{ snippet: string }> };
+    expect(payload.references).toHaveLength(5);
 
     // Assert - references are sorted by relevance (first should have highest similarity)
-    expect(data.references[0].snippet).toContain("chunk 0");
+    expect(payload.references[0]!.snippet).toContain("chunk 0");
   });
 
   it("should degrade gracefully when retrieval fails", async () => {
     // Arrange - mock embedding to throw error
     mockEmbed.mockRejectedValue(new Error("Embedding service unavailable"));
 
-    // Arrange - mock AI response (should still work)
-    mockGenerateText.mockResolvedValue({
-      text: "I can still help you, though I cannot access course materials right now.",
-    });
+    mockStreamText.mockImplementation(
+      ({ onFinish }: { onFinish?: () => void }) => ({
+        toDataStreamResponse: ({ data }: { data: InstanceType<typeof MockStreamData> }) =>
+          buildStreamResponse(
+            "I can still help you, though I cannot access course materials right now.",
+            data,
+            onFinish
+          ),
+      })
+    );
 
     const request = new NextRequest("http://localhost:3000/api/chat", {
       method: "POST",
@@ -258,16 +321,17 @@ describe("Chat API with RAG", () => {
 
     // Act
     const response = await POST(request);
-    const data = await response.json();
+    const { text, data } = await readDataStream(response);
 
     // Assert - response still works
     expect(response.status).toBe(200);
-    expect(data.content).toBeDefined();
+    expect(text).toBeTruthy();
 
     // Assert - no references due to error
-    expect(data.references).toEqual([]);
+    const payload = data[0] as { references: unknown[] };
+    expect(payload.references).toEqual([]);
 
-    // Assert - generateText was still called (graceful degradation)
-    expect(mockGenerateText).toHaveBeenCalled();
+    // Assert - streamText was still called (graceful degradation)
+    expect(mockStreamText).toHaveBeenCalled();
   });
 });

--- a/tests/integration/chat-rag.test.ts
+++ b/tests/integration/chat-rag.test.ts
@@ -52,6 +52,11 @@ vi.mock("@ai-sdk/openai", () => ({
   }),
 }));
 
+vi.mock("#/lib/constants", async (importOriginal) => {
+  const original = await importOriginal<typeof import("#/lib/constants")>();
+  return { ...original, RAG_ENABLED: true };
+});
+
 vi.mock("#/db", () => ({
   db: {
     select: mockSelect,

--- a/tests/unit/Chat.keyboard.test.tsx
+++ b/tests/unit/Chat.keyboard.test.tsx
@@ -28,11 +28,12 @@ describe('Chat keyboard submission', () => {
   beforeEach(() => {
     ;(globalThis as unknown as Record<string, unknown>).SpeechRecognition = MockSpeechRecognition
     ;(globalThis as unknown as Record<string, unknown>).webkitSpeechRecognition = MockSpeechRecognition
-    mockSubmitMessages.mockResolvedValue({
-      id: '99',
-      role: 'assistant',
-      content: 'AI response',
-    })
+    mockSubmitMessages.mockImplementation(
+      async (_msgs: unknown, _userMsg: unknown, onChunk: (t: string) => void, onComplete: (refs: []) => void) => {
+        onChunk('AI response')
+        onComplete([])
+      }
+    )
   })
 
   afterEach(vi.clearAllMocks)

--- a/tests/unit/Chat.microphone.test.tsx
+++ b/tests/unit/Chat.microphone.test.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
 import Chat from '../../src/components/Chat'
 
+// todo: can we move these mocks deeper, say to the boundary with the Deepgram sdk?
 vi.mock('../../src/utils/deepgramHelpers', () => ({
   startDeepgramRecording: vi.fn(),
   stopDeepgramRecording: vi.fn(),
@@ -33,12 +34,14 @@ describe('Chat microphone', () => {
     ;(globalThis as unknown as Record<string, unknown>).SpeechRecognition = MockSpeechRecognition
     ;(globalThis as unknown as Record<string, unknown>).webkitSpeechRecognition = MockSpeechRecognition
 
+    const streamBody = '0:"AI response"\nd:{"finishReason":"stop"}\n'
     vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
       ok: true,
-      json: vi.fn().mockResolvedValue({
-        id: 'ai-1',
-        role: 'assistant',
-        content: 'AI response',
+      body: new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(streamBody))
+          controller.close()
+        },
       }),
     }))
   })

--- a/tests/unit/Chat.microphone.test.tsx
+++ b/tests/unit/Chat.microphone.test.tsx
@@ -143,7 +143,10 @@ describe('Chat microphone', () => {
       await import('../../src/utils/deepgramHelpers')
 
     render(<Chat />)
-    // Clear calls from component mount/StrictMode lifecycle before testing submit behavior
+    // Start recording first so there is something to pause on submit
+    const micButton = screen.getByRole('button', { name: /start recording/i })
+    await waitFor(() => expect(micButton).not.toBeDisabled())
+    await user.click(micButton)
     vi.clearAllMocks()
 
     const textarea = screen.getByPlaceholderText('Type your message...')
@@ -162,6 +165,10 @@ describe('Chat microphone', () => {
       await import('../../src/utils/deepgramHelpers')
 
     render(<Chat />)
+    // Start recording first so resumeAfterResponse has something to resume
+    const micButton = screen.getByRole('button', { name: /start recording/i })
+    await waitFor(() => expect(micButton).not.toBeDisabled())
+    await user.click(micButton)
     vi.clearAllMocks()
 
     const textarea = screen.getByPlaceholderText('Type your message...')
@@ -171,5 +178,28 @@ describe('Chat microphone', () => {
     await waitFor(() => {
       expect(resumeDeepgramMicrophone).toHaveBeenCalled()
     })
+  })
+
+  it('does not pause or resume microphone when submitting without recording', async () => {
+    const user = userEvent.setup()
+    const { pauseMicrophone, resumeDeepgramMicrophone } =
+      await import('../../src/utils/deepgramHelpers')
+
+    render(<Chat />)
+    vi.clearAllMocks()
+
+    // Default TTS is Deepgram; mic is in Stopped state (never clicked)
+    const textarea = screen.getByPlaceholderText('Type your message...')
+    await user.type(textarea, 'hello')
+    await user.keyboard('{Enter}')
+
+    await waitFor(() => {
+      expect(screen.getByText('AI response')).toBeInTheDocument()
+    })
+
+    expect(pauseMicrophone).not.toHaveBeenCalled()
+    expect(resumeDeepgramMicrophone).not.toHaveBeenCalled()
+    // Mic button should still show "Start recording" (Stopped state), not "Stop recording" (Recording state)
+    expect(screen.getByRole('button', { name: 'Start recording' })).toBeInTheDocument()
   })
 })

--- a/tests/unit/Chat.microphone.test.tsx
+++ b/tests/unit/Chat.microphone.test.tsx
@@ -127,6 +127,11 @@ describe('Chat microphone', () => {
     await waitFor(() => expect(micButton).not.toBeDisabled())
     await user.click(micButton)
 
+    // After clicking, mic should be active
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /stop recording/i })).toBeInTheDocument()
+    )
+
     const textarea = screen.getByPlaceholderText('Type your message...')
     await user.type(textarea, 'hello')
     await user.keyboard('{Enter}')
@@ -137,9 +142,9 @@ describe('Chat microphone', () => {
     )
   })
 
-  it('pauses deepgram mic on submit without calling stopDeepgramRecording', async () => {
+  it('pauses deepgram mic on submit and resumes after response, without calling stopDeepgramRecording', async () => {
     const user = userEvent.setup()
-    const { pauseMicrophone, stopDeepgramRecording } =
+    const { pauseMicrophone, stopDeepgramRecording, resumeDeepgramMicrophone } =
       await import('../../src/utils/deepgramHelpers')
 
     render(<Chat />)
@@ -147,6 +152,11 @@ describe('Chat microphone', () => {
     const micButton = screen.getByRole('button', { name: /start recording/i })
     await waitFor(() => expect(micButton).not.toBeDisabled())
     await user.click(micButton)
+
+    // After clicking, mic should be in Loading state
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /loading microphone/i })).toBeInTheDocument()
+    )
     vi.clearAllMocks()
 
     const textarea = screen.getByPlaceholderText('Type your message...')
@@ -156,28 +166,13 @@ describe('Chat microphone', () => {
     await waitFor(() => {
       expect(pauseMicrophone).toHaveBeenCalled()
       expect(stopDeepgramRecording).not.toHaveBeenCalled()
-    })
-  })
-
-  it('resumes deepgram mic after response is received', async () => {
-    const user = userEvent.setup()
-    const { resumeDeepgramMicrophone } =
-      await import('../../src/utils/deepgramHelpers')
-
-    render(<Chat />)
-    // Start recording first so resumeAfterResponse has something to resume
-    const micButton = screen.getByRole('button', { name: /start recording/i })
-    await waitFor(() => expect(micButton).not.toBeDisabled())
-    await user.click(micButton)
-    vi.clearAllMocks()
-
-    const textarea = screen.getByPlaceholderText('Type your message...')
-    await user.type(textarea, 'test message')
-    await user.keyboard('{Enter}')
-
-    await waitFor(() => {
       expect(resumeDeepgramMicrophone).toHaveBeenCalled()
     })
+
+    // After response, mic should be back in Recording state
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /stop recording/i })).toBeInTheDocument()
+    )
   })
 
   it('does not pause or resume microphone when submitting without recording', async () => {


### PR DESCRIPTION
**Implements Streamed Answers**
  - Replaces the single blocking generateText call with a streaming response pipeline so tokens appear progressively in the chat. References from the RAG pipeline are piggybacked on the stream and rendered after the response completes.
   - Switched chat/route.ts from generateText to streamText + StreamData; references appended before streaming begins                             
  - Rewrote submitMessages to use onChunk/onComplete callbacks, parsing the Vercel AI data stream line-by-line
  - Updated Chat.tsx to add a streaming placeholder message, grow it per chunk, and finalize with references on completion                       
  - Moved "AI is thinking..." indicator into Messages.tsx with a pulse animation; replaced isLoading-driven display with empty-content detection 
  - Added RAG_ENABLED toggle in constants.ts to **disable** retrieval without code changes                                                           
  - Fixed a microphone state bug where submitting without recording put the mic button into a phantom Recording state; guarded pauseForSubmit    
  with an isRecordingOrLoading check                                                                                                             
  - Added e2e tests using page.route() to mock the streaming API response; added integration tests for the RAG route; updated unit tests for the 
  new callback signature and mic state transitions